### PR TITLE
Add a few missing packages for tutorial, and pin ipykernel due to bug

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: cryointhecloud
+name: cryocloud
 
 channels:
   - conda-forge
@@ -53,6 +53,12 @@ dependencies:
 
   # Jupyter tools
   - ipython==8.6.0
+  
+  # Warning: There's a bug in ipykernel 6.18 that crashes hvplot.
+  # See https://github.com/ipython/ipykernel/pull/1037. Restriction
+  # can be relaxed once that's fixed.
+  - ipykernel=6.16.0
+  
   - ipywidgets==7.7.2
   - jupyterlab-favorites==3.1.0
   - jupyterlab-geojson==3.3.1
@@ -66,7 +72,9 @@ dependencies:
   - seaborn==0.12.1 # statistical plotting with matplotlib
   - ipympl==0.9.2 # This enables matplotlib interaction with jupyter widgets
   - ipyleaflet==0.17.2
-  - bokeh==3.0.2
+  - bokeh==2.4.3
+  - geoviews==1.9.5
+  - hvplot==0.8.2
   - plotly==5.11.0
 
   # Geospatial data packages
@@ -81,7 +89,8 @@ dependencies:
   - h5netcdf==1.1.0
   - pooch==1.6.0
 
-  # Distributed computing
+  # Distributed computing and cloud tools
+  - boto3
   - dask==2022.11.0
   - dask-labextension==6.0.0
 
@@ -103,6 +112,5 @@ dependencies:
   - pip==22.3.1
   - pip:
     - jupyter-syncthing-proxy
-
-      # Access linux desktop from inside JupyterHub
+    # Access linux desktop from inside JupyterHub
     - jupyter-desktop-server


### PR DESCRIPTION
- Adds boto3 and holoviews-related tools used by the ICESat-2 tutorial.
- Pins ipykernel to 6.16.0 until [this bug is resolved](https://github.com/ipython/ipykernel/pull/1037).
- Reconciles environment name with the one on the main site repo, we'll use `cryocloud` for the env name henceforth.

cc @tsnow03 to check the tutorial with the binder in case I missed anything.