### PR TITLE
Add badge for image build and docker CI workflow improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,6 @@ jobs:
         DOCKER_REGISTRY: "quay.io"
         # Disable pushing a 'latest' tag, as this often just causes confusion
         LATEST_TAG_OFF: true
-
         IMAGE_NAME: "cryointhecloud/cryo-hub-image"
 
     # Lets us monitor disks getting full as images get bigger over time

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'apt.txt'
+      - 'conda-linux-64.lock'
+      - 'environment.yml'
 
 jobs:
   build-and-push:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,9 +26,7 @@ jobs:
       with: # make sure username & password/token matches your registry
         NO_PUSH: "true"
         DOCKER_REGISTRY: "quay.io"
-
-        # Uncomment and modify the following line with your image name.
-        # IMAGE_NAME: "<quay-username>/<repository-name>"
+        IMAGE_NAME: "cryointhecloud/cryo-hub-image"
 
     # Lets us monitor disks getting full as images get bigger over time
     - name: Show how much disk space is left

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,10 @@ name: Test container image build
 
 on:
   pull_request:
+    paths:
+      - 'apt.txt'
+      - 'conda-linux-64.lock'
+      - 'environment.yml'
 
 jobs:
   test-build:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # CryoInTheCloud JupyterHub user image
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/CryoInTheCloud/hub-image/HEAD)
+[![Build and push container image](https://github.com/CryoInTheCloud/hub-image/actions/workflows/build.yaml/badge.svg)](https://github.com/CryoInTheCloud/hub-image/actions/workflows/build.yaml)
 
-The JupyterHub image used for [hub.cryointhecloud.com](https://cryointhecloud.com).
+The JupyterHub docker image used for [hub.cryointhecloud.com](https://cryointhecloud.com),
+hosted on https://quay.io/repository/cryointhecloud/cryo-hub-image
 
 ## Adding packages to this repository
 


### PR DESCRIPTION
Pointing out where the docker image is hosted on the main README.md, and a few edits to the Continuous Integration docker build infrastructure.

- Adding the [![Build and push container image](https://github.com/CryoInTheCloud/hub-image/actions/workflows/build.yaml/badge.svg)](https://github.com/CryoInTheCloud/hub-image/actions/workflows/build.yaml) badge to the main README.md and mention image is hosted at https://quay.io/repository/cryointhecloud/cryo-hub-image
- Fixing an issue on the `.github/workflow/test.yaml` which didn't set the docker image name (cherry-picked from a5d8379b30fb4e634f9b6ab71f7ab7065293b2fc).
- Only run docker build and push to registry when dependency files (`apt.txt`, `environment.yml`, `conda-linux-64.lock`) have changed.