### PR TITLE
Set REPO_DIR for built images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,8 @@ jobs:
         # Disable pushing a 'latest' tag, as this often just causes confusion
         LATEST_TAG_OFF: true
         IMAGE_NAME: "cryointhecloud/cryo-hub-image"
+        # Put repo contents in /srv/repo, so they aren't mangled when we put user home in /home/jovyan
+        REPO_DIR: /srv/repo
 
     # Lets us monitor disks getting full as images get bigger over time
     - name: Show how much disk space is left

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,8 @@ jobs:
         NO_PUSH: "true"
         DOCKER_REGISTRY: "quay.io"
         IMAGE_NAME: "cryointhecloud/cryo-hub-image"
+        # Put repo contents in /srv/repo, so they aren't mangled when we put user home in /home/jovyan
+        REPO_DIR: /srv/repo
 
     # Lets us monitor disks getting full as images get bigger over time
     - name: Show how much disk space is left


### PR DESCRIPTION
Otherwise launching on JupyterHub fails with

```
Traceback (most recent call last):
  File "/usr/local/bin/repo2docker-entrypoint", line 114, in <module>
    main()
  File "/usr/local/bin/repo2docker-entrypoint", line 58, in main
    child = subprocess.Popen(
  File "/srv/conda/envs/notebook/lib/python3.10/subprocess.py", line 971, in _init_
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/srv/conda/envs/notebook/lib/python3.10/subprocess.py", line 1847, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/jovyan/start'
```