### PR TITLE
Fix access app ID/URL to match the previously installed one

### DIFF
--- a/start
+++ b/start
@@ -15,7 +15,7 @@ export DISPLAY=":1.0"
 
 # Tell gh-scoped-creds which GitHub app to use for push access
 # See https://github.com/jupyterhub/gh-scoped-creds#github-app-configuration
-export GH_SCOPED_CREDS_CLIENT_ID="Iv1.7fc8f5dd854835fc"
-export GH_SCOPED_CREDS_APP_URL="https://github.com/apps/cryocloud-github-push-access"
+export GH_SCOPED_CREDS_CLIENT_ID="Iv1.bd27058fd393e285"
+export GH_SCOPED_CREDS_APP_URL="https://github.com/apps/cryocloud-github-access"
 
 exec "$@"


### PR DESCRIPTION
I had already created one and had propagated that info to other users, who may have installed/configured it on their repos.  I don't want to have to ask individual users to change their config if they've already done it. Easier to just fix these IDs.