### PR TITLE
Workflow to retag docker images with CalVer string

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,5 +3,6 @@
 - binder.yaml - Adds a Binder badge to Pull Requests that are newly opened
 - build.yaml - Build and push docker container images to a docker registry
 - conda-lock-command.yml - Refresh conda-lock files by writing `/condalock` in a Pull Request comment
+- retag.yml - Republish docker images originally tagged with a short hash using a new CalVer string
 - slash-command-dispatch.yml - ChatOps that looks for slash commands in Pull Requests to trigger automated scripts
 - test.yaml - Test building docker container images in a Pull Request

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -41,15 +41,10 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
     - name: Pull Image for Corresponding GitHub Commit
-      run: |
-        docker pull quay.io/cryointhecloud/cryo-hub-image:${SHA12}
+      run: docker pull quay.io/cryointhecloud/cryo-hub-image:${SHA12}
 
     - name: Retag Images
-      run: |
-        docker tag cryointhecloud/cryo-hub-image:${SHA12} quay.io/cryointhecloud/cryo-hub-image:latest
-        docker tag cryointhecloud/cryo-hub-image:${SHA12} quay.io/cryointhecloud/cryo-hub-image:${TAG}
+      run: docker tag cryointhecloud/cryo-hub-image:${SHA12} quay.io/cryointhecloud/cryo-hub-image:${TAG}
 
     - name: Push Tags To Quay.io
-      run: |
-        docker push quay.io/cryointhecloud/cryo-hub-image:latest
-        docker push quay.io/cryointhecloud/cryo-hub-image:${TAG}
+      run: docker push quay.io/cryointhecloud/cryo-hub-image:${TAG}

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -1,0 +1,58 @@
+# Re-tag staging SHA-tagged image with git tag and 'latest'
+# tags can be anything, but typically calver string (2022.12.02)
+name: Retag
+on:
+  push:
+    tags:
+    - '*'
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  retag-using-calver:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+    - name: Free up disk space
+      run: |
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+        df -h
+
+    - name: Set Job Environment Variables
+      run: |
+        SHA12="${GITHUB_SHA::12}"
+        TAG="${GITHUB_REF##*/}"
+        echo "SHA12=${SHA12}" >> $GITHUB_ENV
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Quay.io
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Pull Image for Corresponding GitHub Commit
+      run: |
+        docker pull quay.io/cryointhecloud/cryo-hub-image:${SHA12}
+
+    - name: Retag Images
+      run: |
+        docker tag cryointhecloud/cryo-hub-image:${SHA12} quay.io/cryointhecloud/cryo-hub-image:latest
+        docker tag cryointhecloud/cryo-hub-image:${SHA12} quay.io/cryointhecloud/cryo-hub-image:${TAG}
+
+    - name: Push Tags To Quay.io
+      run: |
+        docker push quay.io/cryointhecloud/cryo-hub-image:latest
+        docker push quay.io/cryointhecloud/cryo-hub-image:${TAG}

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -20,12 +20,6 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
 
-    # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-        df -h
-
     - name: Set Job Environment Variables
       run: |
         SHA12="${GITHUB_SHA::12}"

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -27,9 +27,6 @@ jobs:
         echo "SHA12=${SHA12}" >> $GITHUB_ENV
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
     - name: Login to Quay.io
       uses: docker/login-action@v2
       with:

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -20,6 +20,12 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
 
+    # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+    - name: Free up disk space
+      run: |
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+        df -h
+
     - name: Set Job Environment Variables
       run: |
         SHA12="${GITHUB_SHA::12}"


### PR DESCRIPTION
More human readable Calendar Version ([CalVer](https://calver.org/)) tags for docker images published on the docker registry!

Steps to trigger this workflow:
1. Make a git tag manually, or on https://github.com/CryoInTheCloud/hub-image/tags. Note that this tag should ideally be in CalVer format (e.g. `2022.12.02`)
2. The tag will trigger this Continuous Integration workflow `retag.yml` which will:
  1. Pull down the build docker image from https://quay.io/repository/cryointhecloud/cryo-hub-image corresponding to the git commit that was tagged
  2. The docker image will be retagged to a name like `2022.12.02`
  3. This retagged docker image is then pushed back up to the docker registry

GitHub Actions workflow adapted from https://github.com/pangeo-data/pangeo-docker-images/blob/2022.12.01/.github/workflows/Publish.yml

Motivated by https://github.com/CryoInTheCloud/hub-image/issues/11#issue-1467447054 and https://github.com/CryoInTheCloud/hub-image/pull/13#issuecomment-1331621869.