### PR TITLE
Add more complete LaTeX stack to better support publishing

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -36,16 +36,22 @@ perl-doc
 build-essential
 gfortran
 
-# Dependencies for nbconvert
+# Dependencies for nbconvert and myst
+# LaTeX tools
 texlive-xetex
-texlive-fonts-recommended
 texlive-plain-generic
+texlive-fonts-extra
+texlive-fonts-recommended
 texlive-lang-chinese
+texlive-science
+latexmk
 lmodern
+latexdiff
 
 # Other useful document-related tools
 pandoc
-latexdiff
+imagemagick
+# /end nbconvert/myst tools
 
 # Some useful git utilities use basic Ruby
 ruby


### PR DESCRIPTION
This adds key tools that myst regularly uses to build PDFs.  They are just regular TeX packages that are likely to be useful to users beyond the myst toolchain.

This is still a small subset of all possible texlive packages, we may get more requests for a good minimal TeX stack as people begin using it more.