### PR TITLE
Fix `/condalock` command

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -41,8 +41,10 @@ jobs:
           python-version: '3.10'
 
       # Install conda-lock library
+      # HACK: Temporarily pin urllib3<2 to resolve incompatibilities:
+      #       https://github.com/ionrock/cachecontrol/issues/292
       - name: Install conda-lock
-        run: pip install conda-lock
+        run: 'pip install conda-lock "urllib3<2"'
 
       # Run "conda-lock" for linux-64 only
       - name: Run conda-lock


### PR DESCRIPTION
It was broken by a release of `urllib 2.x` which was incompatible with `cachecontrol`. A future release of `cachecontrol` may add this pin to its own dependencies or otherwise fix the incompatibility, at which time the hacky pin can be removed.

Closes #57