### PR TITLE
Resolve error when desktop directory already exists

### DIFF
--- a/start
+++ b/start
@@ -20,7 +20,7 @@ export GH_SCOPED_CREDS_APP_URL="https://github.com/apps/cryocloud-github-access"
 APPLICATIONS_DIR="${HOME}/.local/share/applications"
 DESKTOP_DIR="${HOME}/Desktop"
 mkdir -p "${APPLICATIONS_DIR}"
-mkdir "${DESKTOP_DIR}"
+mkdir -p "${DESKTOP_DIR}"
 for desktop_file_path in ${REPO_DIR}/*.desktop; do
     cp "${desktop_file_path}" "${APPLICATIONS_DIR}/."
 


### PR DESCRIPTION
This was my fault. I forgot about the dual function of `-p`. It doesn't just create parent dirs, but also prevents failures if the directory already exists. I removed `-p` in my last pull request because I only remembered the first behavior, and thought if the home dir doesn't exist we'd want that step to fail.

https://github.com/2i2c-org/infrastructure/pull/2550