### PR TITLE
Restore man pages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,8 @@ jobs:
         IMAGE_NAME: "cryointhecloud/cryo-hub-image"
         # Put repo contents in /srv/repo, so they aren't mangled when we put user home in /home/jovyan
         REPO_DIR: /srv/repo
+        # Fix man pages that are disabled by Ubuntu 18 minimal base image
+        APPENDIX_FILE: "appendix"
 
     # Lets us monitor disks getting full as images get bigger over time
     - name: Show how much disk space is left

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ described above, you can skip the first line):
 
 ```
 conda-lock lock --mamba --kind explicit --file environment.yml --platform linux-64
-repo2docker .
+repo2docker --apendix "$(cat appendix)" .
 ```
 
 This build may take up to 30 minutes.

--- a/appendix
+++ b/appendix
@@ -1,0 +1,13 @@
+# Re-enable man pages disabled in Ubuntu 18 minimal image
+# https://wiki.ubuntu.com/Minimal
+USER root
+RUN yes | unminimize
+# NOTE: $NB_PYTHON_PREFIX is the same as $CONDA_PREFIX at run-time.
+# $CONDA_PREFIX isn't available in this context.
+# NOTE: Prepending ensures a working path; if $MANPATH was previously empty,
+# the trailing colon ensures that system paths are searched.
+ENV MANPATH="${NB_PYTHON_PREFIX}/share/man:${MANPATH}"
+RUN mandb
+
+# Revert to default user
+USER ${NB_USER}


### PR DESCRIPTION
The appendix file method was the only way I could find to successfully `unminimize` the minimal image and bring back man pages.

EDIT: This brings total image size to 11.3 GB from 8.16GB. `unminimize` is probably bringing back more than `man` pages. Maybe there is a way we can restore `man` pages without using the full `unminimize` script?

Resolves #63 