### PR TITLE
Resolve error if symlink or file already exists

### DIFF
--- a/start
+++ b/start
@@ -26,7 +26,7 @@ for desktop_file_path in ${REPO_DIR}/*.desktop; do
 
     # Symlink application to desktop
     desktop_file_name="$(basename ${desktop_file_path})"
-    ln -s "${APPLICATIONS_DIR}/${desktop_file_name}" "${DESKTOP_DIR}/${desktop_file_name}"
+    ln -sf "${APPLICATIONS_DIR}/${desktop_file_name}" "${DESKTOP_DIR}/${desktop_file_name}"
 done
 update-desktop-database "${APPLICATIONS_DIR}"
 


### PR DESCRIPTION
Should resolve this error:

https://github.com/2i2c-org/infrastructure/pull/2560

I'd like to document how to test the effects of mounting the network homedir on my local machine. For example:

```
mkdir -p /tmp/fakehome
repo2docker -v "/tmp/fakehome:/home/$USER" .
```

This doesn't work as I expect; `repo2docker` expects the repo's configuration files to exist in `/home/$USER` and throws `FileNotFoundError: [Errno 2] No such file or directory: '/home/mfisher/start'`.

The volume `"$PWD:/home/$USER"` is better, but `repo2docker` throws `PermissionError: [Errno 13] Permission denied: '/home/mfisher/start'`. If I make the file executable, I can then start up the container. However, my git repository is now polluted with all the build/startup artifacts (`.config/`, `.jupyter/`, `.local/`, `.mozilla/`, `Desktop/`). I used this method (started the container up once, it created all the artifacts, then started it again and it didn't fail this time) to test this pull request should lead to a successful build, but would like to document a better method, if possible :)