### PR TITLE
Remove python-mode

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -l {0}

--- a/apt.txt
+++ b/apt.txt
@@ -16,7 +16,6 @@ wget
 vim
 emacs-nox
 emacs-goodies-el
-python-mode
 
 # A couple of CLI editors that are easier than vim
 # micro  # currently not working on 18.04


### PR DESCRIPTION
Need to remove packages in apt.txt like [`python-mode`](https://packages.ubuntu.com/focal/python-mode) which is not available in Ubuntu 22.04 Jammy Jellyfish, because the default docker base image used by repo2docker has changed from `docker.io/library/buildpack-deps:bionic` (18.04) to `docker.io/library/buildpack-deps:jammy` (22.04), see https://github.com/jupyterhub/repo2docker/issues/1304.

Xref https://github.com/CryoInTheCloud/hub-image/pull/89#issuecomment-1726959611.