### PR TITLE
Install conda-lock with mamba for faster solves

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -35,16 +35,15 @@ jobs:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
-      # Setup Python environment
-      - uses: actions/setup-python@v4
+      # Install conda-lock library with Micromamba
+      - name: Install conda-lock with Micromamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: '3.10'
-
-      # Install conda-lock library
-      # HACK: Temporarily pin urllib3<2 to resolve incompatibilities:
-      #       https://github.com/ionrock/cachecontrol/issues/292
-      - name: Install conda-lock
-        run: 'pip install conda-lock "urllib3<2"'
+          environment-name: conda-lock-env
+          create-args: >-
+            python=3.11
+            conda-lock
+            mamba
 
       # Run "conda-lock" for linux-64 only
       - name: Run conda-lock


### PR DESCRIPTION
Default conda solver is too slow, so using [mamba solver](https://conda.github.io/conda-lock/flags/#-mamba) instead. Need to install `conda-lock` from conda-forge instead of PyPI to also get `mamba`.

Implements suggestion by @MattF-NSIDC in https://github.com/CryoInTheCloud/hub-image/pull/90#discussion_r1333165066 to fix timeout issue from refreshing lockfile.

References:
- Similar implementation that `pangeo-docker-images` uses at https://github.com/pangeo-data/pangeo-docker-images/blob/2023.09.19/.github/workflows/CondaLock.yml#L31-L35
- Related PR https://github.com/weiji14/conda-lock-refresh/pull/4 switching from PyPI-only `conda-lock`  to conda-forge's `conda-lock`+`mamba`