### PR TITLE
Update env Jupyter extensions, Python 3.11, QGIS 3.34 + others second try

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,11 @@
 name: cryocloud
 
-channels:
-  - conda-forge
-  - nodefaults
-
 dependencies:
-  - python~=3.10.10
+  - python~=3.11.0
   # Required until https://github.com/jupyterhub/repo2docker/pull/1196 is merged
-  - jupyterhub-singleuser>=3.0,<4.0
+  - jupyterhub-singleuser~=4.0.1
   # nbgitpuller is very helpful when distributing user content
-  - nbgitpuller==1.1.1
+  - nbgitpuller~=1.2.0
   # Specify major version of jupyterlab to use. Manually bump it when you want to upgrade
   # jupyterlab version
   - jupyterlab>=4.0,<4.1
@@ -18,22 +14,32 @@ dependencies:
   # https://syncthing.net/ provides a dropbox-like interface for syncing directories across users,
   # hubs and machines. Used along with `jupyter-syncthing-proxy`.
   - jupyter-syncthing-proxy==1.0.3
-  - syncthing==1.22.1
+  - syncthing~=1.22.1
   # gh-scoped-creds allows users to securely push to GitHub from their repo.
   # https://blog.jupyter.org/securely-pushing-to-github-from-a-jupyterhub-3ee42dfdc54f has
   # some more information
   - gh-scoped-creds==4.1
   # More git tools from github-cli
   - gh~=2.32.1
+  
+  # VS Code support
+  - jupyter-vscode-proxy~=0.5
+  - code-server~=4.16.1
 
   # Jupyter tools
   - ipython~=8.20.0
   - ipywidgets~=8.1.1
-  - jupyterlab-favorites==3.1.0
+  - jupyter-ai~=2.9.1
+  - jupyter-book~=0.15.1
+#  - jupyter-offlinenotebook~=0.2.2 # Outdated according to jupyterlab
+#  - jupyter-collaboration~=2.0.1 # Causing save issues
+  - jupyterlab-favorites~=3.2.1
   - jupyterlab-geojson~=3.4.0
   - jupyterlab-git~=0.50.0
+  - jupyterlab-h5web~=11.1.0
   - jupyterlab-myst~=2.1.0
-  - jupyter-book~=0.15.1
+#  - jupyterlab-plotly~=5.18.0 # Outdated accoring to jupyterlab
+  - jupyterlab_pygments~=0.3.0 # To bring extension uptodate
   - jupytext~=1.16.1
   - nbconvert==6.5.3
   - nbdime~=4.0.1
@@ -42,23 +48,23 @@ dependencies:
   - cython==0.29.32 # optimization, C API access
   - hypothesis==6.58.0 # needed by numpy testing tools
   - networkx==2.8.8
-  - numba==0.56.4 # high-performance numerics
+  - numba~=0.58.1 # high-performance numerics
   - numpy==1.23.5
-  - pandas~=1.5.1
+  - pandas>=2.0.1,<3.0
   - scikit-image==0.19.3
-  - scikit-learn==1.1.3
+  - scikit-learn>=1.2.2,<2.0.0
   - scipy==1.9.3
   - statsmodels==0.13.5
-  - sympy==1.11.1
+  - sympy~=1.12
   - xarray>=2023.05.0
 
   # Visualization packages
   - bokeh~=3.2.2
-  - cartopy~=0.21.1 # geospatial plotting with matplotlib
+  - cartopy~=0.22.0 # geospatial plotting with matplotlib
   - geoviews~=1.10.1
   - hvplot~=0.8.4
   - ipyleaflet~=0.17.3
-  - ipympl==0.9.3 # This enables matplotlib interaction with jupyter widgets
+  - ipympl~=0.9.3 # This enables matplotlib interaction with jupyter widgets
   - matplotlib~=3.8.0
   - plotly~=5.18.0
   - seaborn==0.12.1 # statistical plotting with matplotlib
@@ -96,11 +102,11 @@ dependencies:
 
   # Distributed computing
   - dask>=2023.12.1
-  - dask-labextension==6.0.0
+  - dask-labextension~=7.0.0
   - dask-geopandas~=0.3.1
-
+  
   # Other useful generic python packages
-  - pillow~=9.5 # Python imaging library, useful for many image-related tasks
+  - pillow~=10.2.0 # Python imaging library, useful for many image-related tasks
   - pytest==7.2.0
   - pytest-cov==4.0.0
   - pep8==1.7.1
@@ -114,12 +120,12 @@ dependencies:
   # Packages specific to cryo work
   - h5coro~=0.0.6
   - icepyx~=0.8.1
-  - itslive~=0.3.0
+  - itslive~=0.3.2
   - is2view~=0.0.5
   - sliderule~=4.0.0
 
   # Desktop tools whose versions are more recent on conda-forge than ubuntu
-  - qgis~=3.28.6
+  - qgis~=3.34.0
   # Maybe needed for qgis? https://github.com/conda-forge/qgis-feedstock/issues/263
   - pyopencl
   # Resolves warning "No ICDs were found": https://github.com/CryoInTheCloud/hub-image/issues/50
@@ -128,10 +134,10 @@ dependencies:
   - websockify>=0.10
   # Includes new subcommands (`switch` & `restore`) and vulnerability fixes
   # over the version available via ubuntu sources
-  - git >=2.39
+  - git>=2.39
 
   # Not all packages will be available from conda-forge, we install from pip when we need to.
-  - pip==22.3.1
+  - pip~=23.3.2
   - pip:
     # Access linux desktop from inside JupyterHub
     - jupyter-desktop-server==0.1.3

--- a/environment.yml
+++ b/environment.yml
@@ -104,7 +104,7 @@ dependencies:
   - dask>=2023.12.1
   - dask-labextension~=7.0.0
   - dask-geopandas~=0.3.1
-  
+
   # Other useful generic python packages
   - pillow~=10.2.0 # Python imaging library, useful for many image-related tasks
   - pytest==7.2.0


### PR DESCRIPTION
See details of the testing for this pull request in https://github.com/CryoInTheCloud/hub-image/pull/104.

This pull request addresses https://github.com/CryoInTheCloud/hub-image/issues/102. Building on @weiji14 's progress in https://github.com/CryoInTheCloud/hub-image/pull/103.

General updates/adds: `Python 3.11`, `QGIS 3.34`, `jupyterlab-h5web`, `jupyter-collaboration`, and `VScode`. 

Updated packages:
`python` from 3.10.1 to 3.11
`jupyterhub-singleuser` from >=3.0,<4.0 to >=4.0
`nbgitpuller` from 1.1.1 to 1.2.0 (not required)
`jupyterlab-favorites` from 3.1.0 to 3.2.0
`scikit-learn` >=1.2.2,<2.0.0
`pip` from 22.3.1 to 23.3.2
`itslive` from 0.3.0 to 3.0.2
`pandas` from 1.5.1 to >=2.0.1,<3.0

To bring jupyter labextensions up-to-date, added:
`jupyterlab_pygments` 0.3.0
`dask-lab-extension` from 0.6.0 to 0.7.0

Added:
`jupyter-vscode-proxy` 0.5
`code-server` 4.16.1
`jupyterlab-h5web` 11.1.0
`jupyter-ai` 2.9.1

For `qgis` from 3.28 to 3.34:
`numba` from 0.56.4 to 0.58.1
`cartopy` from 0.21.1 to 0.22.0
`pillow` from 9.5 to 10.2.0

Could not add jupyter-collaboration because it causes the save button to stop working. Waiting on this issue to resolve to add this https://github.com/jupyterlab/jupyter-collaboration/issues/219.

Could not update to `python 3.12` because `numba` has not been updated to be compatible with it yet. 