### PR TITLE
Let conda-lock produce both unified and platform-specific lockfiles

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -48,7 +48,8 @@ jobs:
       # Generate unified 'conda-lock.yml' and platform-specific lockfiles
       - name: Run conda-lock
         run: |
-          conda-lock lock --mamba --kind lock --kind explicit --file environment.yml --platform linux-64
+          conda-lock lock --mamba --kind lock --file environment.yml --platform linux-64
+          conda-lock render --kind explicit --platform linux-64
 
       # Commit the change to the PR branch if any changes
       - name: Commit condalock files to PR

--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -48,7 +48,7 @@ jobs:
       # Generate unified 'conda-lock.yml' and platform-specific lockfiles
       - name: Run conda-lock
         run: |
-          conda-lock lock --mamba --kind lock --file environment.yml --platform linux-64
+          conda-lock lock --mamba --file environment.yml --platform linux-64
           conda-lock render --kind explicit --platform linux-64
 
       # Commit the change to the PR branch if any changes

--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -45,10 +45,10 @@ jobs:
             conda-lock
             mamba
 
-      # Run "conda-lock" for linux-64 only
+      # Generate unified 'conda-lock.yml' and platform-specific lockfiles
       - name: Run conda-lock
         run: |
-          conda-lock lock --mamba --kind explicit --file environment.yml --platform linux-64
+          conda-lock lock --mamba --kind lock --kind explicit --file environment.yml --platform linux-64
 
       # Commit the change to the PR branch if any changes
       - name: Commit condalock files to PR


### PR DESCRIPTION
Running `conda-lock lock --kind=lock` to produce a unified 'conda-lock.yml' file, and then `conda-lock render` to get a platform-specific 'conda-linux-64.lock' file as before.

Fixes #122.