### PR TITLE
Extend conda-lock timeout to 60m

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
#137 and #138 are seeing timeouts locking the environment. This may help? Let's try!