### PR TITLE
Increase conda-lock timeout from 1 to 2 hours

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
More dependencies means the `conda-lock` solver is taking longer to solve (e.g. at #137), so increasing timeout from 1 to 2hours, following https://github.com/pangeo-data/pangeo-docker-images/pull/608.