### PR TITLE
Increase conda-lock timeout from 2 to 6 hours

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 360
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Two hours is still not enough apparently :joy:, so increasing to six hours, which is actually the default in https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

Supersedes #141.