### PR TITLE
feat: add pixi

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -155,6 +155,7 @@ dependencies:
   # Includes new subcommands (`switch` & `restore`) and vulnerability fixes
   # over the version available via ubuntu sources
   - git>=2.39
+  - pixi
 
   # Not all packages will be available from conda-forge, we install from pip when we need to.
   - pip~=25.0.0

--- a/pixi/config.toml
+++ b/pixi/config.toml
@@ -1,0 +1,1 @@
+detached-environments = "/tmp/pixi"

--- a/postBuild
+++ b/postBuild
@@ -7,3 +7,4 @@ set -euo pipefail
 # used in the JupyterHub.
 cp custom_jupyter_server_config.json ${NB_PYTHON_PREFIX}/etc/jupyter/jupyter_server_config.d/
 cp custom_jupyter_server_config.json ${NB_PYTHON_PREFIX}/etc/jupyter/jupyter_notebook_config.d/
+cp pixi/config.toml /etc/pixi/config.toml


### PR DESCRIPTION
This PR starts the process of adding `pixi` with detached environments, as per the support ticket opened with 2i2c.

However, I haven't rebuilt the lockfile yet -- something's up here, as CI is taking longer each time the lockfile is updated. It's now at 4h, which is definitely wrong!