### PR TITLE
remove line breaks in parsed run command in condalock workflow

### DIFF
--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -46,11 +46,11 @@ jobs:
         shell: micromamba-shell {0}
         run: >
           conda-lock lock
-            --kind lock
-            --kind explicit
-            --file environment.yml
-            --without-cuda
-            --platform linux-64
+          --kind lock
+          --kind explicit
+          --file environment.yml
+          --without-cuda
+          --platform linux-64
 
       # Commit the change to the PR branch if any changes
       - name: Commit condalock files to PR


### PR DESCRIPTION
YAML Multi-line strings using the ">" character preserve newlines followed by any indentation relative to the current line. That broke the `conda-lock` command into multiple commands, accidentally.