### PR TITLE
Bump GitHub Action workflows to those compatible with Node 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,14 +48,14 @@ jobs:
 
       - name: Authenticate with distribution registry
         if: github.repository == 'CryoInTheCloud/hub-image' && github.event_name == 'push'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.username }}
           password: ${{ secrets.password }}
 
       - name: Authenticate with cache registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/conda-lock-command.yml
+++ b/.github/workflows/conda-lock-command.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Install conda-lock library with Micromamba
       - name: Install conda-lock with Micromamba
-        uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2.0.7
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           environment-name: conda-lock-env
           create-args: conda-lock

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -36,7 +36,7 @@ jobs:
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
     - name: Login to Quay.io
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -25,7 +25,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Been getting some deprecation warnings on various jobs. Upgrading actions that were using Node 20 to 24 so as to reduce on noise.

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462, peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/